### PR TITLE
refactor(chart-engine): tighten typing for bar overlay helpers

### DIFF
--- a/clean_slides/chart_engine/annotations.py
+++ b/clean_slides/chart_engine/annotations.py
@@ -52,7 +52,7 @@ def add_text_label(
     height: float,
     align: PP_ALIGN = PP_ALIGN.CENTER,
     color: RGBColor | str | None = _DEFAULT_TEXT_COLOR,
-    font_size: Pt = DEFAULT_WATERFALL_LABEL_FONT_SIZE,
+    font_size: Pt | int | float = DEFAULT_WATERFALL_LABEL_FONT_SIZE,
     fill_color: RGBColor | str | None = None,
     shape_type: MSO_SHAPE | None = None,
     margin_left: int | float | None = None,

--- a/clean_slides/chart_engine/overlay_bar_legend.py
+++ b/clean_slides/chart_engine/overlay_bar_legend.py
@@ -1,43 +1,71 @@
 """Legend overlay helpers for bar charts."""
 
-# pyright: reportUnknownMemberType=false
-# pyright: reportUnknownParameterType=false
-# pyright: reportUnknownVariableType=false
-# pyright: reportUnknownArgumentType=false
-# pyright: reportMissingParameterType=false
-# pyright: reportMissingTypeArgument=false
-# pyright: reportGeneralTypeIssues=false
-# pyright: reportArgumentType=false
-# pyright: reportCallIssue=false
-# pyright: reportAttributeAccessIssue=false
-
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any, Callable, Union, cast
 
+from pptx.dml.color import RGBColor
 from pptx.enum.shapes import MSO_SHAPE
 from pptx.enum.text import PP_ALIGN
-from pptx.oxml.xmlchemy import OxmlElement
+from pptx.util import Pt
 
-from .annotations import add_text_label
+from . import annotations as _annotations
+from . import text_templates as _text_templates
 from .colors import resolve_color
 from .text_style import normalize_alignment
-from .text_templates import resolve_txbody_template
+
+Number = Union[int, float]
+PathOrNone = Union[Path, None]
+StrOrNone = Union[str, None]
+ColorValue = Union[RGBColor, str, None]
+TemplateMap = Mapping[str, object]
+LegendGeometry = Mapping[str, float]
+
+AddTextLabelFn = Callable[..., object]
+ResolveTemplateFn = Callable[[PathOrNone, str, object], object]
+
+
+def _require_attr(module: object, name: str) -> object:
+    value = getattr(module, name, None)
+    if value is None:
+        raise AttributeError(f"{module!r} does not expose {name}")
+    return value
+
+
+add_text_label = cast(AddTextLabelFn, _require_attr(_annotations, "add_text_label"))
+resolve_txbody_template = cast(
+    ResolveTemplateFn,
+    _require_attr(_text_templates, "resolve_txbody_template"),
+)
+
+
+def _number(value: object, default: Number = 0) -> Number:
+    return value if isinstance(value, (int, float)) else default
+
+
+def _optional_str(value: object) -> StrOrNone:
+    return value if isinstance(value, str) else None
+
+
+def _bool(value: object, default: bool) -> bool:
+    return value if isinstance(value, bool) else default
 
 
 def add_bar_legend(
-    slide,
+    slide: Any,
     *,
-    overlay: dict,
-    chart_box: tuple,
+    overlay: Mapping[str, object],
+    chart_box: tuple[int, int, int, int],
     plot_bottom: float,
-    geometry: dict,
-    series_names: list[str],
-    series_colors: list[str | None],
+    geometry: LegendGeometry,
+    series_names: Sequence[str],
+    series_colors: Sequence[StrOrNone],
     legend_width: int,
     legend_height: int,
-    legend_font: int,
-    legend_color,
+    legend_font: Union[Pt, int, float],
+    legend_color: ColorValue,
     legend_offset: int,
     legend_left_ratio: float,
     legend_step_ratio: float,
@@ -46,18 +74,25 @@ def add_bar_legend(
     marker_width: int,
     marker_height: int,
     marker_y_offset: int,
-    template_path: Path | None,
-    templates: dict[str, OxmlElement | None],
+    template_path: PathOrNone,
+    templates: TemplateMap,
 ) -> None:
     """Render legend labels and optional color markers."""
-    legend_layout = overlay.get("legend_layout")
-    legend_align = normalize_alignment(overlay.get("legend_alignment"))
-    legend_show_markers = overlay.get("legend_show_markers", True)
+    legend_layout = _optional_str(overlay.get("legend_layout"))
+    legend_align = normalize_alignment(_optional_str(overlay.get("legend_alignment")))
+    legend_show_markers = _bool(overlay.get("legend_show_markers", True), True)
+
+    margin_left = _number(overlay.get("legend_label_margin_left", 0), 0)
+    margin_right = _number(overlay.get("legend_label_margin_right", 0), 0)
+    margin_top = _number(overlay.get("legend_label_margin_top", 0), 0)
+    margin_bottom = _number(overlay.get("legend_label_margin_bottom", 0), 0)
+    vertical_anchor = _optional_str(overlay.get("legend_label_anchor")) or "center"
+    bw_mode = _optional_str(overlay.get("legend_label_bw_mode")) or "auto"
 
     if legend_layout == "left":
-        legend_left_offset = overlay.get("legend_left_offset", 0)
-        legend_top_offset = overlay.get("legend_top_offset", 0)
-        legend_step = overlay.get("legend_step", legend_height)
+        legend_left_offset = _number(overlay.get("legend_left_offset", 0), 0)
+        legend_top_offset = _number(overlay.get("legend_top_offset", 0), 0)
+        legend_step = _number(overlay.get("legend_step", legend_height), legend_height)
         legend_x = chart_box[0] + legend_left_offset
         legend_y = plot_bottom + legend_top_offset
         if legend_align is None:
@@ -76,12 +111,12 @@ def add_bar_legend(
                 align=legend_align,
                 font_size=legend_font,
                 color=legend_color,
-                margin_left=overlay.get("legend_label_margin_left", 0),
-                margin_right=overlay.get("legend_label_margin_right", 0),
-                margin_top=overlay.get("legend_label_margin_top", 0),
-                margin_bottom=overlay.get("legend_label_margin_bottom", 0),
-                vertical_anchor=overlay.get("legend_label_anchor", "center"),
-                bw_mode=overlay.get("legend_label_bw_mode", "auto"),
+                margin_left=margin_left,
+                margin_right=margin_right,
+                margin_top=margin_top,
+                margin_bottom=margin_bottom,
+                vertical_anchor=vertical_anchor,
+                bw_mode=bw_mode,
                 txbody_template=resolve_txbody_template(
                     template_path,
                     text,
@@ -94,11 +129,12 @@ def add_bar_legend(
     if legend_align is None:
         legend_align = PP_ALIGN.LEFT
 
+    plot_left = geometry["plot_left"]
+    plot_width = geometry["plot_width"]
+
     for idx, name in enumerate(series_names):
         text = str(name)
-        x = geometry["plot_left"] + geometry["plot_width"] * (
-            legend_left_ratio + legend_step_ratio * idx
-        )
+        x = plot_left + plot_width * (legend_left_ratio + legend_step_ratio * idx)
         add_text_label(
             slide,
             text,
@@ -109,12 +145,12 @@ def add_bar_legend(
             align=legend_align,
             font_size=legend_font,
             color=legend_color,
-            margin_left=overlay.get("legend_label_margin_left", 0),
-            margin_right=overlay.get("legend_label_margin_right", 0),
-            margin_top=overlay.get("legend_label_margin_top", 0),
-            margin_bottom=overlay.get("legend_label_margin_bottom", 0),
-            vertical_anchor=overlay.get("legend_label_anchor", "center"),
-            bw_mode=overlay.get("legend_label_bw_mode", "auto"),
+            margin_left=margin_left,
+            margin_right=margin_right,
+            margin_top=margin_top,
+            margin_bottom=margin_bottom,
+            vertical_anchor=vertical_anchor,
+            bw_mode=bw_mode,
             txbody_template=resolve_txbody_template(
                 template_path,
                 text,
@@ -122,10 +158,9 @@ def add_bar_legend(
             ),
         )
 
-        if legend_show_markers and idx < len(series_colors) and series_colors[idx]:
-            marker_x = geometry["plot_left"] + geometry["plot_width"] * (
-                marker_left_ratio + marker_step_ratio * idx
-            )
+        series_color = series_colors[idx] if idx < len(series_colors) else None
+        if legend_show_markers and series_color:
+            marker_x = plot_left + plot_width * (marker_left_ratio + marker_step_ratio * idx)
             marker_y = legend_y + marker_y_offset
             shape = slide.shapes.add_shape(
                 MSO_SHAPE.RECTANGLE,
@@ -135,7 +170,7 @@ def add_bar_legend(
                 int(marker_height),
             )
             shape.fill.solid()
-            rgb, theme = resolve_color(series_colors[idx])
+            rgb, theme = resolve_color(series_color)
             if theme is not None:
                 shape.fill.fore_color.theme_color = theme
             elif rgb is not None:

--- a/clean_slides/chart_engine/overlay_bar_totals_categories.py
+++ b/clean_slides/chart_engine/overlay_bar_totals_categories.py
@@ -1,45 +1,84 @@
 """Total/category label overlay helpers for bar charts."""
 
-# pyright: reportUnknownMemberType=false
-# pyright: reportUnknownParameterType=false
-# pyright: reportUnknownVariableType=false
-# pyright: reportUnknownArgumentType=false
-# pyright: reportMissingParameterType=false
-# pyright: reportMissingTypeArgument=false
-# pyright: reportGeneralTypeIssues=false
-# pyright: reportArgumentType=false
-# pyright: reportCallIssue=false
-# pyright: reportAttributeAccessIssue=false
-# pyright: reportIndexIssue=false
-# pyright: reportOperatorIssue=false
-
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any, Callable, Union, cast
 
+from pptx.dml.color import RGBColor
 from pptx.enum.text import PP_ALIGN
-from pptx.oxml.xmlchemy import OxmlElement
+from pptx.util import Pt
 
-from .annotations import add_text_label
+from . import annotations as _annotations
+from . import text_templates as _text_templates
 from .geometry import value_to_x, value_to_y
 from .spec_utils import format_label
-from .text_templates import resolve_txbody_template
+
+Number = Union[int, float]
+PathOrNone = Union[Path, None]
+FloatOrNone = Union[float, None]
+NumberOrNone = Union[Number, None]
+IntOrNone = Union[int, None]
+ColorValue = Union[RGBColor, str, None]
+Geometry = Mapping[str, object]
+TemplateMap = Mapping[str, object]
+
+AddTextLabelFn = Callable[..., object]
+ResolveTemplateFn = Callable[[PathOrNone, str, object], object]
+
+
+def _require_attr(module: object, name: str) -> object:
+    value = getattr(module, name, None)
+    if value is None:
+        raise AttributeError(f"{module!r} does not expose {name}")
+    return value
+
+
+add_text_label = cast(AddTextLabelFn, _require_attr(_annotations, "add_text_label"))
+resolve_txbody_template = cast(
+    ResolveTemplateFn,
+    _require_attr(_text_templates, "resolve_txbody_template"),
+)
+
+
+def _number(value: object, default: Number = 0) -> Number:
+    return value if isinstance(value, (int, float)) else default
+
+
+def _str_or_default(value: object, default: str) -> str:
+    return value if isinstance(value, str) else default
+
+
+def _bar_center(geometry: Geometry, idx: int) -> FloatOrNone:
+    bar_centers_obj = geometry.get("bar_centers")
+    if not isinstance(bar_centers_obj, list):
+        return None
+
+    bar_centers = cast(list[object], bar_centers_obj)
+    if idx < 0 or idx >= len(bar_centers):
+        return None
+
+    center = bar_centers[idx]
+    if isinstance(center, (int, float)):
+        return float(center)
+    return None
 
 
 def add_bar_total_labels(
-    slide,
+    slide: Any,
     *,
-    overlay: dict,
-    totals: list,
-    total_label_tops: list,
+    overlay: Mapping[str, object],
+    totals: Sequence[FloatOrNone],
+    total_label_tops: Sequence[FloatOrNone],
     total_width: int,
-    total_widths: list,
+    total_widths: list[IntOrNone],
     total_height: int,
-    total_font: int,
-    total_color,
-    total_label_offsets: list,
-    total_label_offset: int,
-    total_label_offsets_x: list,
+    total_font: Union[Pt, int, float],
+    total_color: ColorValue,
+    total_label_offsets: Sequence[NumberOrNone],
+    total_label_offset: Number,
+    total_label_offsets_x: Sequence[Number],
     orientation: str,
     axis_min: float,
     axis_max: float,
@@ -47,47 +86,63 @@ def add_bar_total_labels(
     plot_top: float,
     plot_width: float,
     plot_height: float,
-    geometry: dict,
-    template_path: Path | None,
-    templates: dict[str, OxmlElement | None],
+    geometry: Geometry,
+    template_path: PathOrNone,
+    templates: TemplateMap,
 ) -> None:
     """Render bar total labels."""
+
+    margin_left = _number(overlay.get("total_label_margin_left", 25400), 25400)
+    margin_right = _number(overlay.get("total_label_margin_right", 25400), 25400)
+    margin_top = _number(overlay.get("total_label_margin_top", 0), 0)
+    margin_bottom = _number(overlay.get("total_label_margin_bottom", 0), 0)
+    vertical_anchor = _str_or_default(overlay.get("total_label_anchor"), "bottom")
+    bw_mode = _str_or_default(overlay.get("total_label_bw_mode"), "gray")
 
     for idx, total_value in enumerate(totals):
         if total_value is None:
             continue
+
         text = format_label(total_value)
         if text is None:
             continue
 
-        label_width = (
-            total_widths[idx]
-            if idx < len(total_widths) and total_widths[idx] is not None
-            else total_width
+        label_width_value: Number = total_width
+        if idx < len(total_widths):
+            configured_width = total_widths[idx]
+            if isinstance(configured_width, (int, float)):
+                label_width_value = configured_width
+        label_width = float(label_width_value)
+
+        offset_axis = _number(
+            total_label_offsets_x[idx] if idx < len(total_label_offsets_x) else 0,
+            0,
         )
-        offset_axis = total_label_offsets_x[idx] if idx < len(total_label_offsets_x) else 0
-        offset = (
-            total_label_offsets[idx]
-            if idx < len(total_label_offsets) and total_label_offsets[idx] is not None
-            else total_label_offset
+
+        offset = _number(
+            total_label_offsets[idx] if idx < len(total_label_offsets) else None,
+            total_label_offset,
         )
-        top_value = (
-            total_label_tops[idx]
-            if idx < len(total_label_tops) and total_label_tops[idx] is not None
-            else total_value
-        )
+
+        top_value = total_label_tops[idx] if idx < len(total_label_tops) else total_value
+        if top_value is None:
+            top_value = total_value
+
+        bar_center = _bar_center(geometry, idx)
+        if bar_center is None:
+            continue
 
         if orientation == "horizontal":
             x_base = value_to_x(top_value, axis_min, axis_max, plot_left, plot_width)
-            if top_value is not None and top_value < 0:
+            if top_value < 0:
                 x = x_base - label_width - offset
             else:
                 x = x_base + offset
-            y = geometry["bar_centers"][idx] - total_height / 2 + offset_axis
+            y = bar_center - total_height / 2 + offset_axis
         else:
-            x = geometry["bar_centers"][idx] - label_width / 2 - offset_axis
+            x = bar_center - label_width / 2 - offset_axis
             y_base = value_to_y(top_value, axis_min, axis_max, plot_top, plot_height)
-            if top_value is not None and top_value < 0:
+            if top_value < 0:
                 y = y_base + offset
             else:
                 y = y_base - total_height - offset
@@ -98,63 +153,75 @@ def add_bar_total_labels(
             x,
             y,
             label_width,
-            total_height,
+            float(total_height),
             font_size=total_font,
             color=total_color,
-            margin_left=overlay.get("total_label_margin_left", 25400),
-            margin_right=overlay.get("total_label_margin_right", 25400),
-            margin_top=overlay.get("total_label_margin_top", 0),
-            margin_bottom=overlay.get("total_label_margin_bottom", 0),
-            vertical_anchor=overlay.get("total_label_anchor", "bottom"),
-            bw_mode=overlay.get("total_label_bw_mode", "gray"),
+            margin_left=margin_left,
+            margin_right=margin_right,
+            margin_top=margin_top,
+            margin_bottom=margin_bottom,
+            vertical_anchor=vertical_anchor,
+            bw_mode=bw_mode,
             txbody_template=resolve_txbody_template(
                 template_path,
                 text,
                 templates.get("total"),
             ),
         )
+
         if label is not None and idx < len(total_widths):
-            total_widths[idx] = label.width
+            rendered_width = getattr(label, "width", None)
+            if isinstance(rendered_width, int):
+                total_widths[idx] = rendered_width
 
 
 def add_bar_category_labels(
-    slide,
+    slide: Any,
     *,
-    overlay: dict,
-    categories: list,
+    overlay: Mapping[str, object],
+    categories: Sequence[object],
     orientation: str,
     plot_left: float,
     plot_bottom: float,
-    geometry: dict,
+    geometry: Geometry,
     category_width: int,
-    category_widths: list,
+    category_widths: Sequence[NumberOrNone],
     category_height: int,
-    category_heights: list,
-    category_offsets: list,
-    category_offset: int,
-    category_font: int,
-    category_color,
-    template_path: Path | None,
-    templates: dict[str, OxmlElement | None],
+    category_heights: Sequence[NumberOrNone],
+    category_offsets: Sequence[Number],
+    category_offset: Number,
+    category_font: Union[Pt, int, float],
+    category_color: ColorValue,
+    template_path: PathOrNone,
+    templates: TemplateMap,
 ) -> None:
     """Render category labels around bars."""
 
+    margin_left = _number(overlay.get("category_label_margin_left", 0), 0)
+    margin_right = _number(overlay.get("category_label_margin_right", 0), 0)
+    margin_top = _number(overlay.get("category_label_margin_top", 0), 0)
+    margin_bottom = _number(overlay.get("category_label_margin_bottom", 0), 0)
+    bw_mode = _str_or_default(overlay.get("category_label_bw_mode"), "auto")
+
     if orientation == "horizontal":
+        vertical_anchor = _str_or_default(overlay.get("category_label_anchor"), "center")
+
         for idx, label in enumerate(categories):
             text = str(label)
-            label_width = (
-                category_widths[idx]
-                if idx < len(category_widths) and category_widths[idx] is not None
-                else category_width
-            )
-            label_height = (
-                category_heights[idx]
-                if idx < len(category_heights) and category_heights[idx] is not None
-                else category_height
-            )
-            offset = category_offsets[idx] if idx < len(category_offsets) else 0
+
+            configured_width = category_widths[idx] if idx < len(category_widths) else None
+            label_width = float(_number(configured_width, category_width))
+
+            configured_height = category_heights[idx] if idx < len(category_heights) else None
+            label_height = float(_number(configured_height, category_height))
+
+            offset = _number(category_offsets[idx] if idx < len(category_offsets) else 0, 0)
+            bar_center = _bar_center(geometry, idx)
+            if bar_center is None:
+                continue
+
             x = plot_left + category_offset - label_width
-            y = geometry["bar_centers"][idx] - label_height / 2 + offset
+            y = bar_center - label_height / 2 + offset
             add_text_label(
                 slide,
                 text,
@@ -165,12 +232,12 @@ def add_bar_category_labels(
                 align=PP_ALIGN.RIGHT,
                 font_size=category_font,
                 color=category_color,
-                margin_left=overlay.get("category_label_margin_left", 0),
-                margin_right=overlay.get("category_label_margin_right", 0),
-                margin_top=overlay.get("category_label_margin_top", 0),
-                margin_bottom=overlay.get("category_label_margin_bottom", 0),
-                vertical_anchor=overlay.get("category_label_anchor", "center"),
-                bw_mode=overlay.get("category_label_bw_mode", "auto"),
+                margin_left=margin_left,
+                margin_right=margin_right,
+                margin_top=margin_top,
+                margin_bottom=margin_bottom,
+                vertical_anchor=vertical_anchor,
+                bw_mode=bw_mode,
                 txbody_template=resolve_txbody_template(
                     template_path,
                     text,
@@ -179,21 +246,24 @@ def add_bar_category_labels(
             )
         return
 
+    vertical_anchor = _str_or_default(overlay.get("category_label_anchor"), "top")
     category_y = plot_bottom + category_offset
+
     for idx, label in enumerate(categories):
         text = str(label)
-        label_width = (
-            category_widths[idx]
-            if idx < len(category_widths) and category_widths[idx] is not None
-            else category_width
-        )
-        label_height = (
-            category_heights[idx]
-            if idx < len(category_heights) and category_heights[idx] is not None
-            else category_height
-        )
-        offset = category_offsets[idx] if idx < len(category_offsets) else 0
-        x = geometry["bar_centers"][idx] - label_width / 2 - offset
+
+        configured_width = category_widths[idx] if idx < len(category_widths) else None
+        label_width = float(_number(configured_width, category_width))
+
+        configured_height = category_heights[idx] if idx < len(category_heights) else None
+        label_height = float(_number(configured_height, category_height))
+
+        offset = _number(category_offsets[idx] if idx < len(category_offsets) else 0, 0)
+        bar_center = _bar_center(geometry, idx)
+        if bar_center is None:
+            continue
+
+        x = bar_center - label_width / 2 - offset
         add_text_label(
             slide,
             text,
@@ -203,12 +273,12 @@ def add_bar_category_labels(
             label_height,
             font_size=category_font,
             color=category_color,
-            margin_left=overlay.get("category_label_margin_left", 0),
-            margin_right=overlay.get("category_label_margin_right", 0),
-            margin_top=overlay.get("category_label_margin_top", 0),
-            margin_bottom=overlay.get("category_label_margin_bottom", 0),
-            vertical_anchor=overlay.get("category_label_anchor", "top"),
-            bw_mode=overlay.get("category_label_bw_mode", "auto"),
+            margin_left=margin_left,
+            margin_right=margin_right,
+            margin_top=margin_top,
+            margin_bottom=margin_bottom,
+            vertical_anchor=vertical_anchor,
+            bw_mode=bw_mode,
             txbody_template=resolve_txbody_template(
                 template_path,
                 text,


### PR DESCRIPTION
## Summary

Follow-up typing cleanup after chart-engine modularization.

This PR removes broad per-file pyright suppressions from two bar-overlay helper modules by introducing explicit runtime-safe typing and typed wrappers around imported helper functions.

## Changes

- `clean_slides/chart_engine/overlay_bar_legend.py`
  - removed top-level pyright suppression block
  - added explicit helper type aliases and coercion helpers
  - added typed wrappers (`_require_attr` + `cast`) for `add_text_label` / `resolve_txbody_template`
  - normalized margin/anchor/bw-mode extraction through typed helpers

- `clean_slides/chart_engine/overlay_bar_totals_categories.py`
  - removed top-level pyright suppression block
  - added typed geometry/value coercion helpers (`_number`, `_str_or_default`, `_bar_center`)
  - added typed wrappers (`_require_attr` + `cast`) for `add_text_label` / `resolve_txbody_template`
  - tightened total/category label sizing and offset math with explicit numeric coercion

- `clean_slides/chart_engine/annotations.py`
  - broadened `add_text_label(..., font_size=...)` typing to accept numeric values (`Pt | int | float`) matching existing runtime behavior

## Validation

- `pre-commit run --all-files`
- `pyright`
- `pytest -q`
