### PR TITLE
refactor(chart-engine): tighten typing for waterfall overlays

### DIFF
--- a/clean_slides/chart_engine/overlay_waterfall.py
+++ b/clean_slides/chart_engine/overlay_waterfall.py
@@ -1,22 +1,11 @@
 """Waterfall overlay orchestration."""
 
-# pyright: reportUnknownMemberType=false
-# pyright: reportUnknownParameterType=false
-# pyright: reportUnknownVariableType=false
-# pyright: reportUnknownArgumentType=false
-# pyright: reportMissingParameterType=false
-# pyright: reportMissingTypeArgument=false
-# pyright: reportGeneralTypeIssues=false
-# pyright: reportArgumentType=false
-# pyright: reportCallIssue=false
-# pyright: reportAttributeAccessIssue=false
-# pyright: reportIndexIssue=false
-# pyright: reportOperatorIssue=false
-# pyright: reportUnknownLambdaType=false
-# pyright: reportPossiblyUnboundVariable=false
-
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any, Union, cast
+
+from pptx.dml.color import RGBColor
 from pptx.util import Emu, Pt
 
 from .defaults import (
@@ -41,31 +30,129 @@ from .overlay_waterfall_labels import (
 )
 from .units import coerce_emu, coerce_line_width, coerce_offset_value
 
+Number = Union[int, float]
+FloatOrNone = Union[float, None]
+ColorValue = Union[RGBColor, str, None]
+SlideSize = Union[tuple[int, int], None]
+
+
+def _number(value: object, default: Number = 0) -> Number:
+    return value if isinstance(value, (int, float)) else default
+
+
+def _float(value: object, default: float = 0.0) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return default
+
+
+def _str(value: object, default: str) -> str:
+    return value.strip().lower() if isinstance(value, str) else default
+
+
+def _mapping(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+
+    typed_mapping = cast(dict[object, object], value)
+    mapped: dict[str, object] = {}
+    for key, item in typed_mapping.items():
+        if isinstance(key, str):
+            mapped[key] = item
+    return mapped
+
+
+def _list(value: object) -> list[object]:
+    if isinstance(value, list):
+        return cast(list[object], value)
+    if isinstance(value, tuple):
+        return list(cast(tuple[object, ...], value))
+    return []
+
+
+def _float_or_none(value: object) -> FloatOrNone:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _float_or_none_list(value: object) -> list[FloatOrNone]:
+    result: list[FloatOrNone] = []
+    for item in _list(value):
+        result.append(_float_or_none(item))
+    return result
+
+
+def _color(value: object) -> ColorValue:
+    if isinstance(value, RGBColor):
+        return value
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _index_set(value: object) -> set[int]:
+    indices: set[int] = set()
+    items: list[object]
+    if isinstance(value, set):
+        items = list(cast(set[object], value))
+    elif isinstance(value, list):
+        items = cast(list[object], value)
+    elif isinstance(value, tuple):
+        items = list(cast(tuple[object, ...], value))
+    else:
+        return indices
+
+    for item in items:
+        if isinstance(item, int):
+            indices.add(item)
+    return indices
+
 
 def add_waterfall_overlays(
-    slide,
-    chart_box: tuple,
-    meta: dict,
-    slide_size: tuple[int, int] | None = None,
+    slide: Any,
+    chart_box: tuple[int, int, int, int],
+    meta: Mapping[str, object],
+    slide_size: SlideSize = None,
 ) -> None:
-    overlay = meta.get("overlay") if meta else None
+    overlay_raw = meta.get("overlay") if meta else None
+    overlay = _mapping(overlay_raw)
     if not overlay:
         return
 
-    categories = overlay.get("categories", [])
-    cumulative_totals = overlay.get("cumulative_totals", [])
-    delta_values = overlay.get("delta_values", [])
-    label_tops = overlay.get("label_tops", [])
-    label_bottoms = overlay.get("label_bottoms", [])
-    total_categories = overlay.get("total_categories", set())
-    chart_series_names = overlay.get("chart_series", [])
-    segment_values = overlay.get("segment_values", {})
+    categories = _list(overlay.get("categories"))
+    cumulative_totals = _float_or_none_list(overlay.get("cumulative_totals"))
+    delta_values = _float_or_none_list(overlay.get("delta_values"))
+    label_tops = _float_or_none_list(overlay.get("label_tops"))
+    label_bottoms = _float_or_none_list(overlay.get("label_bottoms"))
+    total_categories = _index_set(overlay.get("total_categories"))
+    chart_series_names = _list(overlay.get("chart_series"))
 
-    axis_min = meta.get("axis_min", 0)
-    axis_max = meta.get("axis_max", 0)
-    gap_width = int(meta.get("gap_width", 80))
-    plot_layout = meta.get("plot_layout") or DEFAULT_WATERFALL_PLOT_LAYOUT
-    orientation = normalize_orientation(meta.get("orientation"))
+    segment_values_raw = overlay.get("segment_values")
+    segment_values: Mapping[object, object]
+    if isinstance(segment_values_raw, dict):
+        segment_values = cast(dict[object, object], segment_values_raw)
+    else:
+        segment_values = {}
+
+    axis_min = _float(meta.get("axis_min", 0), 0.0)
+    axis_max = _float(meta.get("axis_max", 0), 0.0)
+    gap_width = int(_number(meta.get("gap_width", 80), 80))
+
+    plot_layout_raw = meta.get("plot_layout")
+    if isinstance(plot_layout_raw, dict):
+        typed_plot_layout = cast(dict[object, object], plot_layout_raw)
+        plot_layout = {
+            key: float(value)
+            for key, value in typed_plot_layout.items()
+            if isinstance(key, str) and isinstance(value, (int, float))
+        }
+        if not plot_layout:
+            plot_layout = DEFAULT_WATERFALL_PLOT_LAYOUT
+    else:
+        plot_layout = DEFAULT_WATERFALL_PLOT_LAYOUT
+
+    orientation = normalize_orientation(_str(meta.get("orientation"), "vertical"))
 
     geometry = compute_category_geometry(
         chart_box,
@@ -74,61 +161,69 @@ def add_waterfall_overlays(
         gap_width,
         orientation,
     )
-    plot_top = geometry["plot_top"]
-    plot_height = geometry["plot_height"]
-    plot_left = geometry["plot_left"]
-    plot_width = geometry["plot_width"]
+
+    plot_top = _float(geometry.get("plot_top"), 0.0)
+    plot_height = _float(geometry.get("plot_height"), 0.0)
+    plot_left = _float(geometry.get("plot_left"), 0.0)
+    plot_width = _float(geometry.get("plot_width"), 0.0)
     plot_bottom = plot_top + plot_height
 
     slide_width = slide_size[0] if slide_size else None
+
     axis_span = chart_box[3] if orientation == "vertical" else chart_box[2]
-    label_gap = meta.get("label_gap")
-    if label_gap is None:
-        label_gap = meta.get("label_offset")
-    if label_gap is not None:
-        label_gap = coerce_emu(label_gap) or 0
+    label_gap_raw = meta.get("label_gap")
+    if label_gap_raw is None:
+        label_gap_raw = meta.get("label_offset")
+
+    if label_gap_raw is not None:
+        label_gap_value = coerce_emu(label_gap_raw) or 0
     else:
         ratio = meta.get("label_offset_ratio")
-        if ratio is not None:
-            label_gap = axis_span * float(ratio)
+        if isinstance(ratio, (int, float)):
+            label_gap_value = axis_span * float(ratio)
         elif orientation == "vertical":
-            label_gap = DEFAULT_WATERFALL_LABEL_GAP
+            label_gap_value = int(DEFAULT_WATERFALL_LABEL_GAP)
         else:
-            label_gap = axis_span * float(DEFAULT_WATERFALL_LABEL_OFFSET_RATIO)
+            label_gap_value = axis_span * float(DEFAULT_WATERFALL_LABEL_OFFSET_RATIO)
+
+    label_gap = int(label_gap_value)
     if orientation == "horizontal":
-        label_offset = max(int(label_gap), 0)
+        label_offset = max(label_gap, 0)
     else:
-        label_gap = max(int(label_gap), 0)
+        label_gap = max(label_gap, 0)
         label_offset = label_gap
 
-    connector_style = str(meta.get("connector_style") or "gap").lower()
-    connector_value_mode = str(meta.get("connector_value") or "totals").lower()
+    connector_style = _str(meta.get("connector_style"), "gap")
+    connector_value_mode = _str(meta.get("connector_value"), "totals")
     if connector_value_mode in {"totals", "total", "running", "end"}:
         connector_values = cumulative_totals
     else:
         connector_values = label_tops
 
     connector_width = meta.get("connector_line_width")
-    connector_color = meta.get("connector_line_color")
-    connector_dash = str(meta.get("connector_dash_style") or "long_dash").lower()
-    connector_overlap = meta.get("connector_overlap")
-    if connector_overlap is None:
-        connector_overlap = DEFAULT_WATERFALL_CONNECTOR_OVERLAP
-    else:
-        connector_overlap = coerce_emu(connector_overlap) or 0
+    connector_color = _color(meta.get("connector_line_color"))
+    connector_dash = _str(meta.get("connector_dash_style"), "long_dash")
 
-    connector_inset = meta.get("connector_inset")
-    if connector_inset is None:
-        connector_inset = DEFAULT_WATERFALL_CONNECTOR_INSET if orientation == "horizontal" else 0
+    connector_overlap_raw = meta.get("connector_overlap")
+    if connector_overlap_raw is None:
+        connector_overlap = int(DEFAULT_WATERFALL_CONNECTOR_OVERLAP)
     else:
-        connector_inset = coerce_emu(connector_inset) or 0
+        connector_overlap = coerce_emu(connector_overlap_raw) or 0
+
+    connector_inset_raw = meta.get("connector_inset")
+    if connector_inset_raw is None:
+        connector_inset = (
+            int(DEFAULT_WATERFALL_CONNECTOR_INSET) if orientation == "horizontal" else 0
+        )
+    else:
+        connector_inset = coerce_emu(connector_inset_raw) or 0
 
     if connector_width is not None:
         line_width_value = coerce_line_width(connector_width)
     else:
-        line_width_value = Pt(0.25)
+        line_width_value = int(Pt(0.25))
     if line_width_value is None:
-        line_width_value = Pt(0.25)
+        line_width_value = int(Pt(0.25))
     line_width = max(int(line_width_value), int(Emu(6000)))
 
     if connector_dash == "solid":
@@ -179,7 +274,7 @@ def add_waterfall_overlays(
         plot_top=plot_top,
         plot_width=plot_width,
         plot_height=plot_height,
-        label_gap=int(label_gap),
+        label_gap=label_gap,
         label_offset=label_offset,
         slide_width=slide_width,
     )
@@ -193,13 +288,13 @@ def add_waterfall_overlays(
 
     add_waterfall_value_labels(slide, label_specs)
 
-    category_offset = meta.get("category_label_offset")
-    if category_offset is None:
-        category_offset = meta.get("category_offset")
-    if category_offset is not None:
-        category_offset = coerce_emu(category_offset) or 0
+    category_offset_raw = meta.get("category_label_offset")
+    if category_offset_raw is None:
+        category_offset_raw = meta.get("category_offset")
+
+    if category_offset_raw is not None:
+        category_offset = coerce_emu(category_offset_raw) or 0
     else:
-        axis_span = chart_box[3] if orientation == "vertical" else chart_box[2]
         category_offset = axis_span * DEFAULT_WATERFALL_CATEGORY_OFFSET_RATIO
 
     add_waterfall_category_labels(

--- a/clean_slides/chart_engine/overlay_waterfall_connectors.py
+++ b/clean_slides/chart_engine/overlay_waterfall_connectors.py
@@ -1,19 +1,9 @@
 """Connector rendering helpers for waterfall overlays."""
 
-# pyright: reportUnknownMemberType=false
-# pyright: reportUnknownParameterType=false
-# pyright: reportUnknownVariableType=false
-# pyright: reportUnknownArgumentType=false
-# pyright: reportMissingParameterType=false
-# pyright: reportMissingTypeArgument=false
-# pyright: reportGeneralTypeIssues=false
-# pyright: reportArgumentType=false
-# pyright: reportCallIssue=false
-# pyright: reportAttributeAccessIssue=false
-# pyright: reportIndexIssue=false
-# pyright: reportOperatorIssue=false
-
 from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Union, cast
 
 from pptx.dml.color import RGBColor
 from pptx.enum.shapes import MSO_SHAPE
@@ -21,12 +11,39 @@ from pptx.enum.shapes import MSO_SHAPE
 from .colors import apply_color
 from .geometry import value_to_x, value_to_y
 
+Number = Union[int, float]
+FloatOrNone = Union[float, None]
+ColorValue = Union[RGBColor, str, None]
+Geometry = Mapping[str, object]
+
+
+def _geometry_series(geometry: Geometry, key: str) -> list[float]:
+    raw_values = geometry.get(key)
+    if not isinstance(raw_values, list):
+        return []
+
+    typed_values = cast(list[object], raw_values)
+    series: list[float] = []
+    for item in typed_values:
+        if isinstance(item, (int, float)):
+            series.append(float(item))
+    return series
+
+
+def _connector_value(values: Sequence[FloatOrNone], idx: int) -> FloatOrNone:
+    if idx < 0 or idx >= len(values):
+        return None
+    value = values[idx]
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
 
 def render_waterfall_connectors(
-    slide,
-    categories: list[object],
-    connector_values: list[float | None],
-    geometry: dict,
+    slide: Any,
+    categories: Sequence[object],
+    connector_values: Sequence[FloatOrNone],
+    geometry: Geometry,
     orientation: str,
     axis_min: float,
     axis_max: float,
@@ -35,12 +52,12 @@ def render_waterfall_connectors(
     plot_width: float,
     plot_height: float,
     connector_style: str,
-    connector_inset: int,
-    connector_overlap: int,
+    connector_inset: Number,
+    connector_overlap: Number,
     line_width: int,
-    dash_length: int | None,
+    dash_length: Union[int, None],
     dash_gap: int,
-    connector_color,
+    connector_color: ColorValue,
 ) -> None:
     """Render connector segments between adjacent waterfall categories."""
 
@@ -69,62 +86,70 @@ def render_waterfall_connectors(
             if dash_length is None or dash_length <= 0:
                 add_dash_segment(x, start, line_width, total)
                 return
-            pos = 0.0
-            while pos < total:
-                seg_len = min(dash_length, total - pos)
-                add_dash_segment(x, start + pos, line_width, seg_len)
-                pos += seg_len + dash_gap
-        else:
-            y = min(y1, y2) - line_width / 2
-            start = min(x1, x2)
-            total = abs(x2 - x1)
-            if dash_length is None or dash_length <= 0:
-                add_dash_segment(start, y, total, line_width)
-                return
-            pos = 0.0
-            while pos < total:
-                seg_len = min(dash_length, total - pos)
-                add_dash_segment(start + pos, y, seg_len, line_width)
-                pos += seg_len + dash_gap
 
-    bar_bottoms = geometry.get("bar_bottoms") or []
-    bar_tops = geometry.get("bar_tops") or []
-    bar_rights = geometry.get("bar_rights") or []
-    bar_lefts = geometry.get("bar_lefts") or []
+            pos = 0.0
+            while pos < total:
+                segment_length = min(dash_length, total - pos)
+                add_dash_segment(x, start + pos, line_width, segment_length)
+                pos += segment_length + dash_gap
+            return
+
+        y = min(y1, y2) - line_width / 2
+        start = min(x1, x2)
+        total = abs(x2 - x1)
+        if dash_length is None or dash_length <= 0:
+            add_dash_segment(start, y, total, line_width)
+            return
+
+        pos = 0.0
+        while pos < total:
+            segment_length = min(dash_length, total - pos)
+            add_dash_segment(start + pos, y, segment_length, line_width)
+            pos += segment_length + dash_gap
+
+    bar_bottoms = _geometry_series(geometry, "bar_bottoms")
+    bar_tops = _geometry_series(geometry, "bar_tops")
+    bar_rights = _geometry_series(geometry, "bar_rights")
+    bar_lefts = _geometry_series(geometry, "bar_lefts")
+
+    inset = float(connector_inset)
+    overlap = float(connector_overlap)
 
     for idx in range(len(categories) - 1):
-        if idx >= len(connector_values):
-            continue
-        current_value = connector_values[idx]
+        current_value = _connector_value(connector_values, idx)
         if current_value is None:
             continue
-        next_value = connector_values[idx + 1] if idx + 1 < len(connector_values) else None
+
+        next_value = _connector_value(connector_values, idx + 1)
 
         if orientation == "horizontal":
             if idx >= len(bar_bottoms) or idx + 1 >= len(bar_tops):
                 continue
-            x_pos = value_to_x(current_value, axis_min, axis_max, plot_left, plot_width)
-            x_pos -= connector_inset
+
+            x_pos = value_to_x(current_value, axis_min, axis_max, plot_left, plot_width) - inset
             base_start = bar_bottoms[idx]
             base_end = bar_tops[idx + 1]
-            y_start = base_start - connector_overlap
-            y_end = base_end + connector_overlap
+            y_start = base_start - overlap
+            y_end = base_end + overlap
             add_connector(x_pos, y_start, x_pos, y_end)
+
             if connector_style == "step" and next_value is not None:
-                next_x = value_to_x(next_value, axis_min, axis_max, plot_left, plot_width)
-                next_x -= connector_inset
+                next_x = value_to_x(next_value, axis_min, axis_max, plot_left, plot_width) - inset
                 if next_x != x_pos:
                     add_connector(x_pos, base_end, next_x, base_end)
-        else:
-            if idx >= len(bar_rights) or idx + 1 >= len(bar_lefts):
-                continue
-            y_pos = value_to_y(current_value, axis_min, axis_max, plot_top, plot_height)
-            base_start = bar_rights[idx]
-            base_end = bar_lefts[idx + 1]
-            x_start = base_start - connector_overlap
-            x_end = base_end + connector_overlap
-            add_connector(x_start, y_pos, x_end, y_pos)
-            if connector_style == "step" and next_value is not None:
-                next_y = value_to_y(next_value, axis_min, axis_max, plot_top, plot_height)
-                if next_y != y_pos:
-                    add_connector(base_end, y_pos, base_end, next_y)
+            continue
+
+        if idx >= len(bar_rights) or idx + 1 >= len(bar_lefts):
+            continue
+
+        y_pos = value_to_y(current_value, axis_min, axis_max, plot_top, plot_height)
+        base_start = bar_rights[idx]
+        base_end = bar_lefts[idx + 1]
+        x_start = base_start - overlap
+        x_end = base_end + overlap
+        add_connector(x_start, y_pos, x_end, y_pos)
+
+        if connector_style == "step" and next_value is not None:
+            next_y = value_to_y(next_value, axis_min, axis_max, plot_top, plot_height)
+            if next_y != y_pos:
+                add_connector(base_end, y_pos, base_end, next_y)

--- a/clean_slides/chart_engine/overlay_waterfall_labels.py
+++ b/clean_slides/chart_engine/overlay_waterfall_labels.py
@@ -1,23 +1,14 @@
 """Label rendering helpers for waterfall overlays."""
 
-# pyright: reportUnknownMemberType=false
-# pyright: reportUnknownParameterType=false
-# pyright: reportUnknownVariableType=false
-# pyright: reportUnknownArgumentType=false
-# pyright: reportMissingParameterType=false
-# pyright: reportMissingTypeArgument=false
-# pyright: reportGeneralTypeIssues=false
-# pyright: reportArgumentType=false
-# pyright: reportCallIssue=false
-# pyright: reportAttributeAccessIssue=false
-# pyright: reportIndexIssue=false
-# pyright: reportOperatorIssue=false
-
 from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Callable, Union, cast
 
 from pptx.enum.text import PP_ALIGN
 
-from .annotations import add_text_label
+from . import annotations as _annotations
+from . import overlay_waterfall_data_labels as _waterfall_data_labels
 from .defaults import (
     DEFAULT_WATERFALL_CATEGORY_LABEL_HEIGHT,
     DEFAULT_WATERFALL_LABEL_MARGIN,
@@ -25,21 +16,91 @@ from .defaults import (
     DEFAULT_WATERFALL_VALUE_LABEL_HEIGHT,
 )
 from .geometry import value_to_x, value_to_y
-from .overlay_waterfall_data_labels import measure_label_width
 from .spec_utils import format_label
 from .units import emu_or_default
 
+Number = Union[int, float]
+FloatOrNone = Union[float, None]
+LabelSpec = dict[str, Union[float, int, str]]
+Geometry = Mapping[str, object]
+MetaSpec = Mapping[str, object]
+
+AddTextLabelFn = Callable[..., object]
+MeasureLabelWidthFn = Callable[[str], int]
+
+
+def _require_attr(module: object, name: str) -> object:
+    value = getattr(module, name, None)
+    if value is None:
+        raise AttributeError(f"{module!r} does not expose {name}")
+    return value
+
+
+add_text_label = cast(AddTextLabelFn, _require_attr(_annotations, "add_text_label"))
+measure_label_width = cast(
+    MeasureLabelWidthFn,
+    _require_attr(_waterfall_data_labels, "measure_label_width"),
+)
+
+
+def _number(value: object, default: Number = 0) -> Number:
+    return value if isinstance(value, (int, float)) else default
+
+
+def _float_or_none(value: object) -> FloatOrNone:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _float_list(value: object) -> list[float]:
+    if not isinstance(value, list):
+        return []
+
+    typed_values = cast(list[object], value)
+    result: list[float] = []
+    for item in typed_values:
+        if isinstance(item, (int, float)):
+            result.append(float(item))
+    return result
+
+
+def _value_at(values: Sequence[FloatOrNone], idx: int) -> FloatOrNone:
+    if idx < 0 or idx >= len(values):
+        return None
+    value = values[idx]
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _optional_float_list(value: object) -> list[FloatOrNone]:
+    if not isinstance(value, list):
+        return []
+
+    typed_values = cast(list[object], value)
+    result: list[FloatOrNone] = []
+    for item in typed_values:
+        result.append(_float_or_none(item))
+    return result
+
+
+def _mapping(value: object) -> dict[object, object]:
+    if not isinstance(value, dict):
+        return {}
+    return cast(dict[object, object], value)
+
 
 def build_waterfall_value_label_specs(
-    meta: dict,
-    categories: list[object],
-    cumulative_totals: list[float | None],
-    delta_values: list[float | None],
-    total_categories,
-    label_tops: list[float | None],
-    label_bottoms: list[float | None],
+    meta: MetaSpec,
+    categories: Sequence[object],
+    cumulative_totals: Sequence[FloatOrNone],
+    delta_values: Sequence[FloatOrNone],
+    total_categories: set[int],
+    label_tops: Sequence[FloatOrNone],
+    label_bottoms: Sequence[FloatOrNone],
     chart_box: tuple[int, int, int, int],
-    geometry: dict,
+    geometry: Geometry,
     orientation: str,
     axis_min: float,
     axis_max: float,
@@ -49,79 +110,84 @@ def build_waterfall_value_label_specs(
     plot_height: float,
     label_gap: int,
     label_offset: int,
-    slide_width: int | None,
-) -> list[dict[str, object]]:
+    slide_width: Union[int, None],
+) -> list[LabelSpec]:
     """Build value-label box specs for waterfall overlays."""
-    label_specs: list[dict[str, object]] = []
+    label_specs: list[LabelSpec] = []
 
-    bar_centers = geometry.get("bar_centers") or []
+    bar_centers = _float_list(geometry.get("bar_centers"))
+    label_decimals = int(_number(meta.get("label_decimals", 0), 0))
 
     for idx, _category in enumerate(categories):
-        total_value = cumulative_totals[idx] if idx < len(cumulative_totals) else None
+        total_value = _value_at(cumulative_totals, idx)
         if total_value is None:
             continue
+
         if idx == 0 or idx in total_categories:
             label_value = total_value
         else:
-            label_value = delta_values[idx] if idx < len(delta_values) else None
-        label_decimals = meta.get("label_decimals", 0)
+            label_value = _value_at(delta_values, idx)
+
         text = format_label(label_value, decimals=label_decimals)
         if text is None:
             continue
+
+        if idx >= len(bar_centers):
+            continue
+
         label_width = measure_label_width(text)
-        label_height = DEFAULT_WATERFALL_VALUE_LABEL_HEIGHT
-        top_value = label_tops[idx] if idx < len(label_tops) else total_value
-        bottom_value = label_bottoms[idx] if idx < len(label_bottoms) else None
+        label_height = int(DEFAULT_WATERFALL_VALUE_LABEL_HEIGHT)
+
+        top_value = _value_at(label_tops, idx)
+        if top_value is None:
+            top_value = total_value
+
+        bottom_value = _value_at(label_bottoms, idx)
         if bottom_value is None:
             bottom_value = top_value
+
         if orientation == "horizontal":
-            if idx >= len(bar_centers):
-                continue
             anchor_value = top_value
             if label_value is not None and label_value < 0:
                 anchor_value = bottom_value
+
             x_base = value_to_x(anchor_value, axis_min, axis_max, plot_left, plot_width)
             if label_value is not None and label_value < 0:
                 x = x_base - label_width - label_offset
             else:
                 x = x_base + label_offset
+
             min_x = chart_box[0] - label_width
-            if slide_width is not None:
-                max_x = slide_width - label_width
-            else:
-                max_x = chart_box[0] + chart_box[2] + label_offset - label_width
+            max_x = (
+                slide_width - label_width
+                if slide_width is not None
+                else chart_box[0] + chart_box[2] + label_offset - label_width
+            )
             if x < min_x:
-                x = min_x
+                x = float(min_x)
             if x > max_x:
-                x = max_x
+                x = float(max_x)
+
             y = bar_centers[idx] - label_height / 2
+            anchor = "middle"
         else:
-            if idx >= len(bar_centers):
-                continue
             x = bar_centers[idx] - label_width / 2
-            if label_value is not None and label_value < 0 and bottom_value is not None:
+            if label_value is not None and label_value < 0:
                 y_base = value_to_y(bottom_value, axis_min, axis_max, plot_top, plot_height)
                 y = y_base + label_gap
+                anchor = "top"
             else:
                 y_base = value_to_y(top_value, axis_min, axis_max, plot_top, plot_height)
                 y = y_base - label_gap - label_height
-
-        anchor = None
-        if orientation == "horizontal":
-            anchor = "middle"
-        elif orientation == "vertical":
-            if label_value is not None and label_value < 0:
-                anchor = "top"
-            else:
                 anchor = "bottom"
 
         label_specs.append(
             {
                 "text": text,
-                "x": x,
-                "y": y,
-                "width": label_width,
-                "height": label_height,
+                "x": float(x),
+                "y": float(y),
+                "width": int(label_width),
+                "height": int(label_height),
                 "vertical_anchor": anchor,
             }
         )
@@ -129,62 +195,87 @@ def build_waterfall_value_label_specs(
     return label_specs
 
 
-def add_waterfall_value_labels(slide, label_specs: list[dict[str, object]]) -> None:
+def add_waterfall_value_labels(slide: Any, label_specs: Sequence[LabelSpec]) -> None:
     """Render prepared value-label specs."""
     for spec in label_specs:
+        text = spec.get("text")
+        x = spec.get("x")
+        y = spec.get("y")
+        width = spec.get("width")
+        height = spec.get("height")
+        vertical_anchor = spec.get("vertical_anchor")
+
+        if not isinstance(text, str):
+            continue
+        if not isinstance(x, (int, float)):
+            continue
+        if not isinstance(y, (int, float)):
+            continue
+        if not isinstance(width, (int, float)):
+            continue
+        if not isinstance(height, (int, float)):
+            continue
+
         add_text_label(
             slide,
-            spec["text"],
-            spec["x"],
-            spec["y"],
-            spec["width"],
-            spec["height"],
+            text,
+            x,
+            y,
+            width,
+            height,
             margin_left=DEFAULT_WATERFALL_LABEL_MARGIN,
             margin_right=DEFAULT_WATERFALL_LABEL_MARGIN,
-            vertical_anchor=spec.get("vertical_anchor"),
+            vertical_anchor=vertical_anchor if isinstance(vertical_anchor, str) else None,
         )
 
 
 def add_waterfall_category_labels(
-    slide,
-    categories: list[object],
+    slide: Any,
+    categories: Sequence[object],
     chart_box: tuple[int, int, int, int],
-    geometry: dict,
+    geometry: Geometry,
     orientation: str,
-    category_offset: int,
+    category_offset: Number,
     plot_left: float,
     plot_bottom: float,
 ) -> None:
     """Render category labels for waterfall overlays."""
-    bar_centers = geometry.get("bar_centers") or []
+    bar_centers = _float_list(geometry.get("bar_centers"))
 
     if orientation == "horizontal":
         for idx, label in enumerate(categories):
             if idx >= len(bar_centers):
                 continue
+
             text = str(label)
             label_width = measure_label_width(text)
             x = plot_left - category_offset - label_width
             min_x = max(0, chart_box[0] - label_width)
             if x < min_x:
-                x = min_x
-            y = bar_centers[idx] - DEFAULT_WATERFALL_CATEGORY_LABEL_HEIGHT / 2
+                x = float(min_x)
+
+            y = bar_centers[idx] - int(DEFAULT_WATERFALL_CATEGORY_LABEL_HEIGHT) / 2
             add_text_label(
                 slide,
                 text,
                 x,
                 y,
                 label_width,
-                DEFAULT_WATERFALL_CATEGORY_LABEL_HEIGHT,
+                int(DEFAULT_WATERFALL_CATEGORY_LABEL_HEIGHT),
                 align=PP_ALIGN.RIGHT,
             )
         return
 
-    slot_width = geometry.get("slot_width")
-    if slot_width is None:
+    slot_width_obj = geometry.get("slot_width")
+    if not isinstance(slot_width_obj, (int, float)):
         return
+
+    slot_width = float(slot_width_obj)
     category_y = plot_bottom + category_offset
-    plot_left_value = geometry.get("plot_left", plot_left)
+
+    plot_left_obj = geometry.get("plot_left", plot_left)
+    plot_left_value = plot_left_obj if isinstance(plot_left_obj, (int, float)) else plot_left
+
     for idx, label in enumerate(categories):
         x = plot_left_value + slot_width * idx
         add_text_label(
@@ -193,17 +284,17 @@ def add_waterfall_category_labels(
             x,
             category_y,
             slot_width,
-            DEFAULT_WATERFALL_CATEGORY_LABEL_HEIGHT,
+            int(DEFAULT_WATERFALL_CATEGORY_LABEL_HEIGHT),
         )
 
 
 def add_waterfall_series_labels(
-    slide,
+    slide: Any,
     chart_box: tuple[int, int, int, int],
-    chart_series_names: list[object],
-    segment_values: dict,
+    chart_series_names: Sequence[object],
+    segment_values: Mapping[object, object],
     orientation: str,
-    meta: dict,
+    meta: MetaSpec,
     axis_min: float,
     axis_max: float,
     plot_top: float,
@@ -219,20 +310,25 @@ def add_waterfall_series_labels(
     )
     series_label_left = emu_or_default(meta.get("series_label_left"), 0)
 
-    stacked = []
+    segment_values_dict = _mapping(segment_values)
+
+    stacked: list[tuple[str, float]] = []
     for name in chart_series_names:
-        values = segment_values.get(name, [])
-        val = values[0] if values else None
-        magnitude = abs(val) if val is not None else 0
-        stacked.append((name, magnitude))
+        values_obj = segment_values_dict.get(name, [])
+        values = _optional_float_list(values_obj)
+        first_value = values[0] if values else None
+        magnitude = abs(first_value) if first_value is not None else 0.0
+        stacked.append((str(name), magnitude))
 
     current = 0.0
     for name, magnitude in stacked:
         if magnitude <= 0:
             continue
+
         center_val = current + magnitude / 2
         current += magnitude
         y = value_to_y(center_val, axis_min, axis_max, plot_top, plot_height)
+
         text = str(name)
         width = measure_label_width(text)
         label_right = chart_box[0] + series_label_inset
@@ -241,8 +337,8 @@ def add_waterfall_series_labels(
             slide,
             text,
             x,
-            y - DEFAULT_WATERFALL_CATEGORY_LABEL_HEIGHT / 2,
+            y - int(DEFAULT_WATERFALL_CATEGORY_LABEL_HEIGHT) / 2,
             width,
-            DEFAULT_WATERFALL_CATEGORY_LABEL_HEIGHT,
+            int(DEFAULT_WATERFALL_CATEGORY_LABEL_HEIGHT),
             align=PP_ALIGN.RIGHT,
         )


### PR DESCRIPTION
## Summary

Typing pass 2 for chart-engine overlays.

This continues the pyright-hardening cleanup by removing broad per-file pyright suppression headers from waterfall overlay modules and replacing ad-hoc dict/list access with explicit typed coercion helpers.

## Changes

- `clean_slides/chart_engine/overlay_waterfall.py`
  - removed broad pyright suppression block
  - added typed normalization helpers for mapping/list/numeric/color extraction
  - normalized overlay/meta values before orchestration calls
  - preserved existing connector/label/category/series behavior while tightening types

- `clean_slides/chart_engine/overlay_waterfall_connectors.py`
  - removed broad pyright suppression block
  - added typed geometry/value extraction helpers
  - kept connector rendering behavior intact (solid/dash/dot + step mode)

- `clean_slides/chart_engine/overlay_waterfall_labels.py`
  - removed broad pyright suppression block
  - added typed wrappers for imported helper functions (`add_text_label`, `measure_label_width`)
  - added typed value/geometry coercion helpers
  - kept value/category/series label placement logic behavior-equivalent

## Validation

- `pre-commit run --all-files`
- `pyright`
- `pytest -q`
