### PR TITLE
refactor(chart-engine): tighten typing for bar overlay modules

### DIFF
--- a/clean_slides/chart_engine/overlay_bar.py
+++ b/clean_slides/chart_engine/overlay_bar.py
@@ -1,27 +1,16 @@
 """Chart overlay and manual label layout helpers."""
 
-# pyright: reportUnknownMemberType=false
-# pyright: reportUnknownParameterType=false
-# pyright: reportUnknownVariableType=false
-# pyright: reportUnknownArgumentType=false
-# pyright: reportMissingParameterType=false
-# pyright: reportMissingTypeArgument=false
-# pyright: reportGeneralTypeIssues=false
-# pyright: reportArgumentType=false
-# pyright: reportCallIssue=false
-# pyright: reportAttributeAccessIssue=false
-# pyright: reportIndexIssue=false
-# pyright: reportOperatorIssue=false
-# pyright: reportUnknownLambdaType=false
-# pyright: reportPossiblyUnboundVariable=false
-
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any, Callable, Union, cast
 
-from pptx.oxml.xmlchemy import OxmlElement
+from pptx.dml.color import RGBColor
+from pptx.util import Pt
 
-from .annotations import add_line_annotation, add_shape_annotation
+from . import annotations as _annotations
+from . import text_templates as _text_templates
 from .defaults import (
     DEFAULT_BAR_CATEGORY_LABEL_FONT_SIZE,
     DEFAULT_BAR_CATEGORY_LABEL_HEIGHT,
@@ -48,30 +37,210 @@ from .geometry import compute_category_geometry, normalize_orientation
 from .overlay_bar_legend import add_bar_legend
 from .overlay_bar_segments import add_bar_segment_labels
 from .overlay_bar_totals_categories import add_bar_category_labels, add_bar_total_labels
-from .text_templates import load_txbody_template
 from .units import resolve_path
 
+Number = Union[int, float]
+FloatOrNone = Union[float, None]
+NumberOrNone = Union[Number, None]
+IntOrNone = Union[int, None]
+StrOrNone = Union[str, None]
+PathOrNone = Union[Path, None]
+BaseDirValue = Union[str, Path, None]
+ColorValue = Union[RGBColor, str, None]
+FontValue = Union[Pt, int, float]
+OverlaySpec = Mapping[str, object]
+MetaSpec = Mapping[str, object]
 
-def add_bar_overlays(slide, chart_box: tuple, meta: dict) -> None:
-    overlay = meta.get("overlay") if meta else None
+AddLineAnnotationFn = Callable[[Any, dict[str, object]], None]
+AddShapeAnnotationFn = Callable[[Any, dict[str, object]], None]
+LoadTemplateFn = Callable[[Path, str], object]
+
+
+def _require_attr(module: object, name: str) -> object:
+    value = getattr(module, name, None)
+    if value is None:
+        raise AttributeError(f"{module!r} does not expose {name}")
+    return value
+
+
+add_line_annotation = cast(
+    AddLineAnnotationFn,
+    _require_attr(_annotations, "add_line_annotation"),
+)
+add_shape_annotation = cast(
+    AddShapeAnnotationFn,
+    _require_attr(_annotations, "add_shape_annotation"),
+)
+load_txbody_template = cast(
+    LoadTemplateFn,
+    _require_attr(_text_templates, "load_txbody_template"),
+)
+
+
+def _mapping(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+
+    typed_mapping = cast(dict[object, object], value)
+    mapped: dict[str, object] = {}
+    for key, item in typed_mapping.items():
+        if isinstance(key, str):
+            mapped[key] = item
+    return mapped
+
+
+def _list(value: object) -> list[object]:
+    if isinstance(value, list):
+        return cast(list[object], value)
+    if isinstance(value, tuple):
+        return list(cast(tuple[object, ...], value))
+    return []
+
+
+def _sequence_matrix(value: object) -> list[Sequence[object]]:
+    matrix: list[Sequence[object]] = []
+    for row in _list(value):
+        if isinstance(row, list):
+            matrix.append(cast(list[object], row))
+        elif isinstance(row, tuple):
+            matrix.append(list(cast(tuple[object, ...], row)))
+    return matrix
+
+
+def _number(value: object, default: Number = 0) -> Number:
+    return value if isinstance(value, (int, float)) else default
+
+
+def _int(value: object, default: int = 0) -> int:
+    return int(_number(value, default))
+
+
+def _float(value: object, default: float = 0.0) -> float:
+    return float(_number(value, default))
+
+
+def _bool(value: object, default: bool) -> bool:
+    return value if isinstance(value, bool) else default
+
+
+def _optional_str(value: object) -> StrOrNone:
+    return value if isinstance(value, str) else None
+
+
+def _base_dir(value: object) -> BaseDirValue:
+    if isinstance(value, (str, Path)):
+        return value
+    return None
+
+
+def _font_value(value: object, default: FontValue) -> FontValue:
+    if isinstance(value, Pt):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    return default
+
+
+def _color(value: object) -> ColorValue:
+    if isinstance(value, (RGBColor, str)):
+        return value
+    return None
+
+
+def _string_list(value: object) -> list[str]:
+    result: list[str] = []
+    for item in _list(value):
+        if isinstance(item, str):
+            result.append(item)
+    return result
+
+
+def _string_or_none_list(value: object) -> list[StrOrNone]:
+    result: list[StrOrNone] = []
+    for item in _list(value):
+        if isinstance(item, str):
+            result.append(item)
+        elif item is None:
+            result.append(None)
+    return result
+
+
+def _float_or_none_list(value: object) -> list[FloatOrNone]:
+    result: list[FloatOrNone] = []
+    for item in _list(value):
+        if isinstance(item, (int, float)):
+            result.append(float(item))
+        else:
+            result.append(None)
+    return result
+
+
+def _number_or_none_list(value: object) -> list[NumberOrNone]:
+    result: list[NumberOrNone] = []
+    for item in _list(value):
+        if isinstance(item, (int, float)):
+            result.append(item)
+        else:
+            result.append(None)
+    return result
+
+
+def _int_or_none_list(value: object) -> list[IntOrNone]:
+    result: list[IntOrNone] = []
+    for item in _list(value):
+        if isinstance(item, (int, float)):
+            result.append(int(item))
+        else:
+            result.append(None)
+    return result
+
+
+def _number_list(value: object) -> list[Number]:
+    result: list[Number] = []
+    for item in _list(value):
+        if isinstance(item, (int, float)):
+            result.append(item)
+    return result
+
+
+def _plot_layout(value: object) -> dict[str, float]:
+    if isinstance(value, dict):
+        typed_mapping = cast(dict[object, object], value)
+        layout = {
+            key: float(item)
+            for key, item in typed_mapping.items()
+            if isinstance(key, str) and isinstance(item, (int, float))
+        }
+        if layout:
+            return layout
+
+    return dict(DEFAULT_BAR_PLOT_LAYOUT)
+
+
+def add_bar_overlays(
+    slide: Any,
+    chart_box: tuple[int, int, int, int],
+    meta: MetaSpec,
+) -> None:
+    overlay = _mapping(meta.get("overlay")) if meta else {}
     if not overlay:
         return
 
-    base_dir = overlay.get("_base_dir")
+    base_dir = _base_dir(overlay.get("_base_dir"))
 
-    categories = overlay.get("categories", [])
-    totals = overlay.get("totals", [])
-    total_label_tops = overlay.get("total_label_tops") or []
-    series_names = overlay.get("series_names", [])
-    series_colors = overlay.get("series_colors", [])
-    show_totals = overlay.get("show_totals", False)
-    show_legend = overlay.get("show_legend_labels", True)
+    categories = _list(overlay.get("categories"))
+    totals = _float_or_none_list(overlay.get("totals"))
+    total_label_tops = _float_or_none_list(overlay.get("total_label_tops"))
+    series_names = _string_list(overlay.get("series_names"))
+    series_colors = _string_or_none_list(overlay.get("series_colors"))
+    show_totals = _bool(overlay.get("show_totals", False), False)
+    show_legend = _bool(overlay.get("show_legend_labels", True), True)
 
-    axis_min = meta.get("axis_min", 0)
-    axis_max = meta.get("axis_max", 0)
-    gap_width = int(meta.get("gap_width", 80))
-    plot_layout = meta.get("plot_layout") or DEFAULT_BAR_PLOT_LAYOUT
-    orientation = normalize_orientation(meta.get("orientation"))
+    axis_min = _float(meta.get("axis_min", 0), 0.0)
+    axis_max = _float(meta.get("axis_max", 0), 0.0)
+    gap_width = _int(meta.get("gap_width", 80), 80)
+    plot_layout = _plot_layout(meta.get("plot_layout"))
+    orientation = normalize_orientation(_optional_str(meta.get("orientation")))
 
     geometry = compute_category_geometry(
         chart_box,
@@ -80,75 +249,135 @@ def add_bar_overlays(slide, chart_box: tuple, meta: dict) -> None:
         gap_width,
         orientation,
     )
-    plot_top = geometry["plot_top"]
-    plot_height = geometry["plot_height"]
-    plot_left = geometry["plot_left"]
-    plot_width = geometry["plot_width"]
+    plot_top = _float(geometry.get("plot_top"), 0.0)
+    plot_height = _float(geometry.get("plot_height"), 0.0)
+    plot_left = _float(geometry.get("plot_left"), 0.0)
+    plot_width = _float(geometry.get("plot_width"), 0.0)
     plot_bottom = plot_top + plot_height
 
-    category_width = overlay.get("category_label_width", DEFAULT_BAR_CATEGORY_LABEL_WIDTH)
-    category_widths = overlay.get("category_label_widths") or []
-    legend_width = overlay.get("legend_label_width", DEFAULT_BAR_LEGEND_LABEL_WIDTH)
-    total_width = overlay.get("total_label_width", DEFAULT_BAR_TOTAL_LABEL_WIDTH)
-    total_widths = overlay.get("total_label_widths") or []
-    category_offsets = overlay.get("category_label_offsets") or []
-
-    category_height = overlay.get("category_label_height", DEFAULT_BAR_CATEGORY_LABEL_HEIGHT)
-    category_heights = overlay.get("category_label_heights") or []
-    legend_height = overlay.get("legend_label_height", DEFAULT_BAR_LEGEND_LABEL_HEIGHT)
-    total_height = overlay.get("total_label_height", DEFAULT_BAR_TOTAL_LABEL_HEIGHT)
-
-    category_font = overlay.get("category_label_font", DEFAULT_BAR_CATEGORY_LABEL_FONT_SIZE)
-    legend_font = overlay.get("legend_label_font", DEFAULT_BAR_LEGEND_LABEL_FONT_SIZE)
-    total_font = overlay.get("total_label_font", DEFAULT_BAR_TOTAL_LABEL_FONT_SIZE)
-
-    category_color = overlay.get("category_label_color")
-    legend_color = overlay.get("legend_label_color")
-    total_color = overlay.get("total_label_color")
-
-    total_label_offsets = overlay.get("total_label_offsets") or []
-
-    legend_left_ratio = overlay.get("legend_left_ratio", DEFAULT_BAR_LEGEND_LEFT_RATIO)
-    legend_step_ratio = overlay.get("legend_step_ratio", DEFAULT_BAR_LEGEND_STEP_RATIO)
-    marker_left_ratio = overlay.get(
-        "legend_marker_left_ratio", DEFAULT_BAR_LEGEND_MARKER_LEFT_RATIO
+    category_width = _int(
+        overlay.get("category_label_width", DEFAULT_BAR_CATEGORY_LABEL_WIDTH),
+        int(DEFAULT_BAR_CATEGORY_LABEL_WIDTH),
     )
-    marker_step_ratio = overlay.get(
-        "legend_marker_step_ratio", DEFAULT_BAR_LEGEND_MARKER_STEP_RATIO
+    category_widths = _number_or_none_list(overlay.get("category_label_widths"))
+    legend_width = _int(
+        overlay.get("legend_label_width", DEFAULT_BAR_LEGEND_LABEL_WIDTH),
+        int(DEFAULT_BAR_LEGEND_LABEL_WIDTH),
     )
-    marker_width = overlay.get("legend_marker_width", DEFAULT_BAR_LEGEND_MARKER_WIDTH)
-    marker_height = overlay.get("legend_marker_height", DEFAULT_BAR_LEGEND_MARKER_HEIGHT)
-    marker_y_offset = overlay.get("legend_marker_y_offset", DEFAULT_BAR_LEGEND_MARKER_Y_OFFSET)
-    total_label_offset = overlay.get("total_label_offset", DEFAULT_BAR_TOTAL_LABEL_OFFSET)
-    total_label_offsets_x = overlay.get("total_label_offsets_x") or []
-    category_offset = overlay.get("category_label_offset", DEFAULT_BAR_CATEGORY_LABEL_OFFSET)
-    legend_offset = overlay.get("legend_label_offset", DEFAULT_BAR_LEGEND_LABEL_OFFSET)
+    total_width = _int(
+        overlay.get("total_label_width", DEFAULT_BAR_TOTAL_LABEL_WIDTH),
+        int(DEFAULT_BAR_TOTAL_LABEL_WIDTH),
+    )
+    total_widths = _int_or_none_list(overlay.get("total_label_widths"))
+    category_offsets = _number_list(overlay.get("category_label_offsets"))
 
-    annotations = overlay.get("annotations") or []
+    category_height = _int(
+        overlay.get("category_label_height", DEFAULT_BAR_CATEGORY_LABEL_HEIGHT),
+        int(DEFAULT_BAR_CATEGORY_LABEL_HEIGHT),
+    )
+    category_heights = _number_or_none_list(overlay.get("category_label_heights"))
+    legend_height = _int(
+        overlay.get("legend_label_height", DEFAULT_BAR_LEGEND_LABEL_HEIGHT),
+        int(DEFAULT_BAR_LEGEND_LABEL_HEIGHT),
+    )
+    total_height = _int(
+        overlay.get("total_label_height", DEFAULT_BAR_TOTAL_LABEL_HEIGHT),
+        int(DEFAULT_BAR_TOTAL_LABEL_HEIGHT),
+    )
+
+    category_font = _font_value(
+        overlay.get("category_label_font", DEFAULT_BAR_CATEGORY_LABEL_FONT_SIZE),
+        DEFAULT_BAR_CATEGORY_LABEL_FONT_SIZE,
+    )
+    legend_font = _font_value(
+        overlay.get("legend_label_font", DEFAULT_BAR_LEGEND_LABEL_FONT_SIZE),
+        DEFAULT_BAR_LEGEND_LABEL_FONT_SIZE,
+    )
+    total_font = _font_value(
+        overlay.get("total_label_font", DEFAULT_BAR_TOTAL_LABEL_FONT_SIZE),
+        DEFAULT_BAR_TOTAL_LABEL_FONT_SIZE,
+    )
+
+    category_color = _color(overlay.get("category_label_color"))
+    legend_color = _color(overlay.get("legend_label_color"))
+    total_color = _color(overlay.get("total_label_color"))
+
+    total_label_offsets = _number_or_none_list(overlay.get("total_label_offsets"))
+
+    legend_left_ratio = _float(
+        overlay.get("legend_left_ratio", DEFAULT_BAR_LEGEND_LEFT_RATIO),
+        float(DEFAULT_BAR_LEGEND_LEFT_RATIO),
+    )
+    legend_step_ratio = _float(
+        overlay.get("legend_step_ratio", DEFAULT_BAR_LEGEND_STEP_RATIO),
+        float(DEFAULT_BAR_LEGEND_STEP_RATIO),
+    )
+    marker_left_ratio = _float(
+        overlay.get("legend_marker_left_ratio", DEFAULT_BAR_LEGEND_MARKER_LEFT_RATIO),
+        float(DEFAULT_BAR_LEGEND_MARKER_LEFT_RATIO),
+    )
+    marker_step_ratio = _float(
+        overlay.get("legend_marker_step_ratio", DEFAULT_BAR_LEGEND_MARKER_STEP_RATIO),
+        float(DEFAULT_BAR_LEGEND_MARKER_STEP_RATIO),
+    )
+    marker_width = _int(
+        overlay.get("legend_marker_width", DEFAULT_BAR_LEGEND_MARKER_WIDTH),
+        int(DEFAULT_BAR_LEGEND_MARKER_WIDTH),
+    )
+    marker_height = _int(
+        overlay.get("legend_marker_height", DEFAULT_BAR_LEGEND_MARKER_HEIGHT),
+        int(DEFAULT_BAR_LEGEND_MARKER_HEIGHT),
+    )
+    marker_y_offset = _int(
+        overlay.get("legend_marker_y_offset", DEFAULT_BAR_LEGEND_MARKER_Y_OFFSET),
+        int(DEFAULT_BAR_LEGEND_MARKER_Y_OFFSET),
+    )
+    total_label_offset = _int(
+        overlay.get("total_label_offset", DEFAULT_BAR_TOTAL_LABEL_OFFSET),
+        int(DEFAULT_BAR_TOTAL_LABEL_OFFSET),
+    )
+    total_label_offsets_x = _number_list(overlay.get("total_label_offsets_x"))
+    category_offset = _int(
+        overlay.get("category_label_offset", DEFAULT_BAR_CATEGORY_LABEL_OFFSET),
+        int(DEFAULT_BAR_CATEGORY_LABEL_OFFSET),
+    )
+    legend_offset = _int(
+        overlay.get("legend_label_offset", DEFAULT_BAR_LEGEND_LABEL_OFFSET),
+        int(DEFAULT_BAR_LEGEND_LABEL_OFFSET),
+    )
+
+    annotations = _list(overlay.get("annotations"))
     for annotation in annotations:
-        if not isinstance(annotation, dict):
+        annotation_spec = _mapping(annotation)
+        if not annotation_spec:
             continue
-        annotation_spec = dict(annotation)
         if base_dir is not None and "_base_dir" not in annotation_spec:
             annotation_spec["_base_dir"] = base_dir
 
-        kind = (annotation_spec.get("type") or "shape").lower()
+        kind_raw = annotation_spec.get("type")
+        kind = kind_raw.lower() if isinstance(kind_raw, str) else "shape"
         if kind == "line":
             add_line_annotation(slide, annotation_spec)
         else:
             add_shape_annotation(slide, annotation_spec)
 
     text_style_template = overlay.get("text_style_template")
-    text_style_map = overlay.get("text_style_map") or {}
-    templates: dict[str, OxmlElement | None] = {}
-    template_path: Path | None = None
-    if isinstance(text_style_template, str):
+    text_style_map = _mapping(overlay.get("text_style_map"))
+
+    templates: dict[str, object] = {}
+    template_path: PathOrNone = None
+
+    if isinstance(text_style_template, Path):
+        template_path = resolve_path(str(text_style_template), base_dir)
+    elif isinstance(text_style_template, str):
         template_path = resolve_path(text_style_template, base_dir)
+
+    if template_path is not None:
         for key, sample in text_style_map.items():
             if isinstance(sample, str):
                 templates[key] = load_txbody_template(template_path, sample)
 
-    segment_values = overlay.get("segment_values") or []
+    segment_values = _sequence_matrix(overlay.get("segment_values"))
     add_bar_segment_labels(
         slide,
         overlay=overlay,
@@ -220,7 +449,10 @@ def add_bar_overlays(slide, chart_box: tuple, meta: dict) -> None:
             overlay=overlay,
             chart_box=chart_box,
             plot_bottom=plot_bottom,
-            geometry=geometry,
+            geometry={
+                "plot_left": plot_left,
+                "plot_width": plot_width,
+            },
             series_names=series_names,
             series_colors=series_colors,
             legend_width=legend_width,

--- a/clean_slides/chart_engine/overlay_bar_segments.py
+++ b/clean_slides/chart_engine/overlay_bar_segments.py
@@ -1,26 +1,15 @@
 """Segment label overlay helpers for bar charts."""
 
-# pyright: reportUnknownMemberType=false
-# pyright: reportUnknownParameterType=false
-# pyright: reportUnknownVariableType=false
-# pyright: reportUnknownArgumentType=false
-# pyright: reportMissingParameterType=false
-# pyright: reportMissingTypeArgument=false
-# pyright: reportGeneralTypeIssues=false
-# pyright: reportArgumentType=false
-# pyright: reportCallIssue=false
-# pyright: reportAttributeAccessIssue=false
-# pyright: reportIndexIssue=false
-# pyright: reportOperatorIssue=false
-# pyright: reportPossiblyUnboundVariable=false
-
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any, Callable, Union, cast
 
-from pptx.oxml.xmlchemy import OxmlElement
+from pptx.dml.color import RGBColor
 
-from .annotations import add_text_label
+from . import annotations as _annotations
+from . import text_templates as _text_templates
 from .defaults import (
     DEFAULT_BAR_SEGMENT_LABEL_FONT_SIZE,
     DEFAULT_BAR_SEGMENT_LABEL_HEIGHT,
@@ -35,22 +24,97 @@ from .spec_utils import (
     numeric_value,
     safe_value,
 )
-from .text_templates import resolve_txbody_template
-from .units import (
-    coerce_offset_value,
-    emu_or_default,
-    normalize_offset_matrix,
+from .units import coerce_offset_value, emu_or_default, normalize_offset_matrix
+
+Number = Union[int, float]
+NumberOrBool = Union[int, float, bool]
+StrOrNone = Union[str, None]
+PathOrNone = Union[Path, None]
+ColorValue = Union[RGBColor, str, None]
+OverlaySpec = Mapping[str, object]
+Geometry = Mapping[str, object]
+TemplateMap = Mapping[str, object]
+
+AddTextLabelFn = Callable[..., object]
+ResolveTemplateFn = Callable[[PathOrNone, str, object], object]
+
+
+def _require_attr(module: object, name: str) -> object:
+    value = getattr(module, name, None)
+    if value is None:
+        raise AttributeError(f"{module!r} does not expose {name}")
+    return value
+
+
+add_text_label = cast(AddTextLabelFn, _require_attr(_annotations, "add_text_label"))
+resolve_txbody_template = cast(
+    ResolveTemplateFn,
+    _require_attr(_text_templates, "resolve_txbody_template"),
 )
 
 
+def _mapping(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+
+    typed_mapping = cast(dict[object, object], value)
+    mapped: dict[str, object] = {}
+    for key, item in typed_mapping.items():
+        if isinstance(key, str):
+            mapped[key] = item
+    return mapped
+
+
+def _number(value: object, default: Number = 0) -> Number:
+    return value if isinstance(value, (int, float)) else default
+
+
+def _int(value: object, default: int = 0) -> int:
+    return int(_number(value, default))
+
+
+def _bool(value: object, default: bool) -> bool:
+    return value if isinstance(value, bool) else default
+
+
+def _geometry_float(geometry: Geometry, key: str) -> float:
+    value = geometry.get(key)
+    if isinstance(value, (int, float)):
+        return float(value)
+    return 0.0
+
+
+def _geometry_series(geometry: Geometry, key: str) -> list[float]:
+    values = geometry.get(key)
+    if not isinstance(values, list):
+        return []
+
+    typed_values = cast(list[object], values)
+    result: list[float] = []
+    for item in typed_values:
+        if isinstance(item, (int, float)):
+            result.append(float(item))
+    return result
+
+
+def _coerce_fill_color(fill_value: object, series_color: StrOrNone) -> ColorValue:
+    if fill_value == "series":
+        return series_color
+    if fill_value in {None, "none", "transparent", False}:
+        return None
+    if isinstance(fill_value, (RGBColor, str)):
+        return fill_value
+    return None
+
+
 def add_bar_segment_labels(
-    slide,
+    slide: Any,
     *,
-    overlay: dict,
-    categories: list,
-    series_names: list[str],
-    series_colors: list[str | None],
-    segment_values: list,
+    overlay: OverlaySpec,
+    categories: Sequence[object],
+    series_names: Sequence[str],
+    series_colors: Sequence[StrOrNone],
+    segment_values: Sequence[Sequence[object]],
     orientation: str,
     axis_min: float,
     axis_max: float,
@@ -58,44 +122,57 @@ def add_bar_segment_labels(
     plot_top: float,
     plot_width: float,
     plot_height: float,
-    geometry: dict,
-    template_path: Path | None,
-    templates: dict[str, OxmlElement | None],
+    geometry: Geometry,
+    template_path: PathOrNone,
+    templates: TemplateMap,
 ) -> None:
     segment_configs = normalize_list(overlay.get("segment_labels"))
-    for segment_cfg in segment_configs:
-        if not segment_cfg or not segment_cfg.get("show", True):
+    categories_list = list(categories)
+
+    bar_tops = _geometry_series(geometry, "bar_tops")
+    bar_height = _geometry_float(geometry, "bar_height")
+    bar_lefts = _geometry_series(geometry, "bar_lefts")
+    bar_width = _geometry_float(geometry, "bar_width")
+
+    for raw_segment_cfg in segment_configs:
+        segment_cfg = _mapping(raw_segment_cfg)
+        if not segment_cfg:
             continue
+        if not _bool(segment_cfg.get("show", True), True):
+            continue
+
         segment_series = normalize_list(
             segment_cfg.get("series_indices")
             or segment_cfg.get("series")
             or segment_cfg.get("series_names")
         )
+
         segment_series_indices: list[int] = []
         for item in segment_series:
             if isinstance(item, int):
                 segment_series_indices.append(item)
             elif isinstance(item, str) and item in series_names:
                 segment_series_indices.append(series_names.index(item))
+
         segment_series_indices = [
             idx for idx in segment_series_indices if 0 <= idx < len(segment_values)
         ]
-
         if not segment_series_indices:
             continue
 
         category_filter = normalize_category_indices(
-            categories,
+            categories_list,
             segment_cfg.get("categories") or segment_cfg.get("category_indices"),
         )
+        category_filter_set: Union[set[int], None]
         category_filter_set = set(category_filter) if category_filter else None
 
         positions = segment_cfg.get("positions")
         if positions is not None:
-            ratios = [float(val) for val in normalize_list(positions)]
+            ratios = [float(cast(NumberOrBool, val)) for val in normalize_list(positions)]
         else:
             offset_ratio = float(
-                segment_cfg.get("offset_ratio", DEFAULT_BAR_SEGMENT_LABEL_OFFSET_RATIO)
+                _number(segment_cfg.get("offset_ratio"), DEFAULT_BAR_SEGMENT_LABEL_OFFSET_RATIO)
             )
             if len(segment_series_indices) == 1:
                 ratios = [0.5]
@@ -113,16 +190,17 @@ def add_bar_segment_labels(
 
         segment_width = emu_or_default(
             segment_cfg.get("width"),
-            DEFAULT_BAR_SEGMENT_LABEL_WIDTH,
+            int(DEFAULT_BAR_SEGMENT_LABEL_WIDTH),
         )
         segment_height = emu_or_default(
             segment_cfg.get("height"),
-            DEFAULT_BAR_SEGMENT_LABEL_HEIGHT,
+            int(DEFAULT_BAR_SEGMENT_LABEL_HEIGHT),
         )
         segment_font = segment_cfg.get("font_size", DEFAULT_BAR_SEGMENT_LABEL_FONT_SIZE)
         segment_color = segment_cfg.get("text_color", "bg1")
         segment_fill = segment_cfg.get("fill", "series")
-        segment_decimals = segment_cfg.get("decimals", 0)
+        segment_decimals = _int(segment_cfg.get("decimals", 0), 0)
+
         segment_offsets_x = [
             coerce_offset_value(val) for val in normalize_list(segment_cfg.get("offsets_x"))
         ]
@@ -136,14 +214,20 @@ def add_bar_segment_labels(
             segment_cfg.get("offsets_y_by_category") or segment_cfg.get("offsets_y_matrix")
         )
 
-        for cat_idx in range(len(categories)):
+        for cat_idx in range(len(categories_list)):
             if category_filter_set and cat_idx not in category_filter_set:
                 continue
+
             running = 0.0
             for series_idx, series_vals in enumerate(segment_values):
                 value = numeric_value(safe_value(series_vals, cat_idx))
                 if value is None:
                     continue
+
+                x_start = 0.0
+                x_end = 0.0
+                y_bottom = 0.0
+                y_top = 0.0
                 if orientation == "horizontal":
                     x_start = value_to_x(running, axis_min, axis_max, plot_left, plot_width)
                     x_end = value_to_x(running + value, axis_min, axis_max, plot_left, plot_width)
@@ -155,21 +239,26 @@ def add_bar_segment_labels(
                     text = format_label(value, decimals=segment_decimals)
                     if text is not None:
                         ratio = ratio_map[series_idx]
+
                         if orientation == "horizontal":
+                            if cat_idx >= len(bar_tops):
+                                running += value
+                                continue
+
                             x_center = (x_start + x_end) / 2
-                            y_center = (
-                                geometry["bar_tops"][cat_idx] + geometry["bar_height"] * ratio
-                            )
+                            y_center = bar_tops[cat_idx] + bar_height * ratio
                         else:
-                            x_center = (
-                                geometry["bar_lefts"][cat_idx] + geometry["bar_width"] * ratio
-                            )
+                            if cat_idx >= len(bar_lefts):
+                                running += value
+                                continue
+
+                            x_center = bar_lefts[cat_idx] + bar_width * ratio
                             y_center = (y_bottom + y_top) / 2
-                        fill_color = None
-                        if segment_fill == "series" and series_idx < len(series_colors):
-                            fill_color = series_colors[series_idx]
-                        elif segment_fill not in {None, "none", "transparent", False}:
-                            fill_color = segment_fill
+
+                        series_color = (
+                            series_colors[series_idx] if series_idx < len(series_colors) else None
+                        )
+                        fill_color = _coerce_fill_color(segment_fill, series_color)
 
                         offset_idx = segment_series_indices.index(series_idx)
                         offset_x = (
@@ -221,5 +310,8 @@ def add_bar_segment_labels(
                             ),
                         )
                         if label is not None:
-                            segment_width = label.width
+                            rendered_width = getattr(label, "width", None)
+                            if isinstance(rendered_width, int):
+                                segment_width = rendered_width
+
                 running += value


### PR DESCRIPTION
## Summary

Typing pass 4 for chart-engine bar overlays.

This removes broad file-level pyright suppressions from the remaining bar overlay orchestration/segment modules and replaces dynamic access with explicit typed normalization while preserving rendering behavior.

## Changes

- `clean_slides/chart_engine/overlay_bar.py`
  - removed broad `# pyright` suppression header
  - added typed coercion helpers for overlay/meta values (list/mapping/numeric/color/font/base-dir parsing)
  - added typed callable wrappers for annotation + txBody template loader imports
  - normalized annotation specs and text-style template loading with typed guards
  - kept existing overlay flow intact (annotations -> segment labels -> totals -> categories -> legend)

- `clean_slides/chart_engine/overlay_bar_segments.py`
  - removed broad `# pyright` suppression header
  - added typed callable wrappers for `add_text_label` and `resolve_txbody_template`
  - normalized segment config parsing and geometry extraction with typed helpers
  - retained segment-label placement/offset behavior and preserved rendered-width feedback loop

## Validation

- `.venv/bin/ruff check clean_slides/chart_engine/overlay_bar.py clean_slides/chart_engine/overlay_bar_segments.py`
- `.venv/bin/pyright clean_slides/chart_engine/overlay_bar.py clean_slides/chart_engine/overlay_bar_segments.py`
- `.venv/bin/pyright`
- `.venv/bin/pytest -q`
- `.venv/bin/pre-commit run --all-files`
